### PR TITLE
fix: filter out deleted jobs

### DIFF
--- a/src/adapter/helpers.ts
+++ b/src/adapter/helpers.ts
@@ -68,7 +68,9 @@ export const findExistingJob = async (
 
   if (items.length) {
     //smartling will fuzzy match job names. We need to be precise.
-    const correctJob = items.find(
+    const correctJob = items
+      .filter((item: {jobStatus: string}) => item.jobStatus !== 'DELETED')
+      .find(
       (item: {jobName: string; referenceNumber: string}) =>
         (item.jobName && item.jobName === documentId) ||
         (item.referenceNumber && item.referenceNumber === documentId),


### PR DESCRIPTION
Filter out deleted jobs while searching for them

While searching for existing jobs, if a previous job has been cancelled, the plugin does still display the `View Job` button. 

When you click on the VIew Job butotn the image below is displayed in Smartling

<img width="1081" alt="Screenshot 2023-09-12 at 10 19 44" src="https://github.com/arthur-pinner/sanity-plugin-studio-smartling/assets/108877194/928ed6cc-a930-4be9-bb0e-e7d5fb6bb3b6">
